### PR TITLE
tweaks to scoped-packages page

### DIFF
--- a/content/getting-started/scoped-packages.md
+++ b/content/getting-started/scoped-packages.md
@@ -11,11 +11,15 @@ Scopes are like namespaces for npm modules. Each npm user has their own scope.
 @username/project-name
 ```
 
-## Update npm and login
+## Update npm and log in
 
-You need a version of npm greater than `2.7.0`. Run `sudo npm install -g npm` to update npm.
+You need a version of npm greater than `2.7.0`, and you'll need to log in to npm again
+on the command line if this is your first time using scoped modules.
 
-You also need to login to npm again if this is your first time using scoped modules. Run `npm login`.
+```sh
+sudo npm install -g npm
+npm login
+```
 
 ## Initializing a scoped package
 
@@ -30,13 +34,13 @@ To create a scoped package, you simply use a package name that starts with your 
 If you use `npm init`, you can add your scope as an option to that command.
 
 ```
-$ npm init --scope=username
+npm init --scope=username
 ```
 
 If you use the same scope all the time, you will probably want to set this option in your `~/.npmrc` file.
 
 ```
-$ npm config set scope username
+npm config set scope username
 ```
 
 ## Using a scoped package
@@ -56,13 +60,13 @@ In package.json:
 On the command line:
 
 ```sh
-$ npm install @username/project-name --save
+npm install @username/project-name --save
 ```
 
 In a `require` statement:
 
 ```js
-var project-name = require("@username/project-name")
+var projectName = require("@username/project-name")
 ```
 
 For information about using scoped private modules, visit [npmjs.com/private-modules](https://www.npmjs.com/private-modules).


### PR DESCRIPTION
- remove leading `$` for consistency with other docs, and so commands can be copied
- `project-name` was not a valid js variable
- clarify where login needs to happen (CLI, not website)