### PR TITLE
Redirect legacy URL /package.json to /files/package.json

### DIFF
--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -1,4 +1,5 @@
 module.exports = {
   "/enterprise/whitelist": "/enterprise/mirroring",
   "/misc/index": "/",
+  "/package.json": "/files/package.json",
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "js-beautify": "^1.5.2",
     "leven": "^1.0.1",
     "lodash": "^2.4.1",
-    "marky-markdown": "^4.1.3",
+    "marky-markdown": "^5.2.0",
     "npm": "latest",
     "strftime": "^0.8.2",
     "walkdir": "0.0.7"

--- a/test/server.js
+++ b/test/server.js
@@ -81,4 +81,12 @@ describe('redirects', function() {
       .expect(301, done)
   })
 
+  it('301s /package.json to /files/package.json', function(done) {
+    supertest(app)
+      .get('/package.json')
+      .expect('Location', /\/files\/package\.json$/)
+      .expect(301, done)
+  })
+
+
 })


### PR DESCRIPTION
This is a fix for https://github.com/npm/newww/issues/458, and an incidental update to marky-markdown.