### PR TITLE
switch from dot notation to bracket notation

### DIFF
--- a/content/enterprise/no-authentication.md
+++ b/content/enterprise/no-authentication.md
@@ -12,9 +12,9 @@ allow everyone access to everything.
 In order to do so, set the following settings in
 [`/etc/npme/service.json`](/enterprise/server-configuration):
 
-  * `args.--authentication-method` and `args.--authorization-method`
+  * `args["--authentication-method"]` and `args["--authorization-method"]`
 to `"fake"`
-  * `args.--session-handler` to `"redis"`
+  * `args["--session-handler"]` to `"redis"`
 
 Make sure to regenerate scripts as described in
 [Customizing server configuration](/enterprise/server-configuration).


### PR DESCRIPTION
Since dot notation properties must be valid JavaScript identifiers, and `--authentication-method` is not a valid JavaScript identifier, it would seem like you need to use bracket notation here.

@mmalecki I assume this was a typo, but let me know if it was intentional.