### PR TITLE
Deleted repeated command for testing installations

### DIFF
--- a/content/getting-started/fixing-npm-permissions.md
+++ b/content/getting-started/fixing-npm-permissions.md
@@ -60,4 +60,4 @@ Test: Download a package globally without using `sudo`.
 
 Instead of steps 2-4 you can also use the corresponding ENV variable (e.g. if you don't want to modify `~/.profile`):
 
-        NPM_CONFIG_PREFIX=~/npm-global npm install -g jshint
+        NPM_CONFIG_PREFIX=~/npm-global


### PR DESCRIPTION
The line 'npm install -g jshint' appears on the same line as the proposed alternative for taking steps 2-4 which seemed like a mistake.