### PR TITLE
changes GA property ID

### DIFF
--- a/views/layout.hbs
+++ b/views/layout.hbs
@@ -117,7 +117,7 @@
       m.parentNode.insertBefore(a, m)
     })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
 
-    ga('create', 'UA-53856291-2', 'auto');
+    ga('create', 'UA-47041310-6', 'auto');
     ga('send', 'pageview');
   </script>
 


### PR DESCRIPTION
was: a discrete Google Analytics _account_, attached to GA testing of `npm-newww`.

is now: a Google Analytics _property_ within the npm _account_.