### PR TITLE
remove API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ The place where all things npm are documented.
 
 All the markdown files can be found in the [content](content) directory. Some of these files live here in this repository, others live in other repositories and are imported during the build process. These imported files are [ignored by git](.gitignore) to prevent people from accidentally editing the wrong files.
 
-- [api](https://github.com/npm/npm/tree/master/doc/api) is copied from [npm](https://github.com/npm/npm/tree/master/doc/api).
-- [cli](https://github.com/npm/npm/tree/master/doc/cli) is copied from npm.
+- [cli](https://github.com/npm/npm/tree/master/doc/cli) is copied from [npm](https://github.com/npm/npm/tree/master/doc/api).
 - [enterprise](content/enterprise) lives in this repo.
 - [files](https://github.com/npm/npm/tree/master/doc/files) is copied from npm.
 - [misc](https://github.com/npm/npm/tree/master/doc/misc) is copied from npm.

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -12,7 +12,6 @@ rm -rf content/policies
 
 # The -p flag preserves file timestamps
 
-cp -pr node_modules/npm/doc/api content/
 cp -pr node_modules/npm/doc/cli content/
 cp -pr node_modules/npm/doc/files content/
 cp -pr node_modules/npm/doc/misc content/

--- a/bin/tree.js
+++ b/bin/tree.js
@@ -35,7 +35,7 @@ emitter.on('file', function (filepath, stat) {
     filename: filepath.replace(/.*\/content\//, ''),
     modified: null,
     modifiedPretty: null,
-    edit_url: 'https://github.com/npm/npm/edit/master/doc/api/npm-bugs.md',
+    edit_url: 'https://github.com/npm/npm/edit/master/doc/cli/npm-bugs.md',
     content: fs.readFileSync(filepath, 'utf-8')
   }
 
@@ -73,7 +73,7 @@ emitter.on('file', function (filepath, stat) {
   }
 
   // In what repository does this doc live?
-  if (['api', 'cli', 'files', 'misc'].indexOf(page.section) > -1) {
+  if (['cli', 'files', 'misc'].indexOf(page.section) > -1) {
     page.edit_url = 'https://github.com/npm/npm/edit/master/doc/' + page.filename
   } else if (page.section === 'policies') {
     page.edit_url = 'https://github.com/npm/policies/edit/master/' + path.basename(page.filename)
@@ -91,7 +91,6 @@ emitter.on('file', function (filepath, stat) {
   }
 
   content.pages.push(page)
-
 })
 
 emitter.on('end', function () {
@@ -101,5 +100,4 @@ emitter.on('end', function () {
 
   fs.writeFileSync(contentFile, JSON.stringify(content, null, 2))
   console.log('Wrote %s', path.relative(process.cwd(), contentFile))
-
 })

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "cors": "^2.4.2",
     "express": "^4.9.5",
     "handlebars-helper-equal": "^1.0.0",
-    "harp": "^0.13.0",
+    "harp": "^0.18.0",
     "hbs": "^2.7.0",
     "html-frontmatter": "^1.2.1",
     "js-beautify": "^1.5.2",

--- a/sections.json
+++ b/sections.json
@@ -17,9 +17,6 @@
   "id": "files",
   "title": "Configuring npm"
 }, {
-  "id": "api",
-  "title": "Using npm programmatically"
-}, {
   "id": "policies",
   "title": "npm policy documents"
 }, {

--- a/test/index.js
+++ b/test/index.js
@@ -106,17 +106,6 @@ describe('content', function () {
       })
     })
 
-    it('points pages in `api` section to the npm repo', function () {
-      var apiPages = content.pages.filter(function (page) {
-        return page.section === 'api'
-      })
-      assert(apiPages.length)
-
-      apiPages.forEach(function (page) {
-        assert.equal(page.edit_url, 'https://github.com/npm/npm/edit/master/doc/' + page.filename)
-      })
-    })
-
   })
 
 })


### PR DESCRIPTION
Two commits:

1. Remove all references to the API documentation, because it doesn't live here anymore.
2. Upgrade `harp` to latest version, both because it makes some assumptions incompatible with `npm@3` (which, unfortunately, is still the case with `harp@0.18.0`), and because it had gotten a little stale and all the tests still pass with it upgraded.

Fixes: npm/issue-tracker#203

**r**: @rockbot