### PR TITLE
replacing hgroup with header tags

### DIFF
--- a/content/company/npm-weekly.md
+++ b/content/company/npm-weekly.md
@@ -1,7 +1,7 @@
-<hgroup>
+<header>
   <h1>npm Weekly</h1>
   <h2>Find out what we've been working on, thinking about, and talking about every week.</h2>
-</hgroup>
+</header>
 
 <form action="//npmjs.us9.list-manage.com/subscribe/post?u=077dfd41302a71310cef619e5&amp;id=e17fe5d778" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
 

--- a/content/company/private-npm.md
+++ b/content/company/private-npm.md
@@ -1,7 +1,7 @@
-<hgroup>
+<header>
 <h1>npm Private Modules</h1>
 <h2>Publish, share and install proprietary code easily</h2>
-</hgroup>
+</header>
 
 Private modules are ordinary npm packages that only you, and people you select,
 can view, install, and publish. You publish them in your namespace or your team's namespace, just by giving them a name in package.json:


### PR DESCRIPTION
Substituting deprecated hgroup tag ^.^. Closing #137 