### PR TITLE
Add note on changing section names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ don't have an `order` property will be relegated to the end of that section.
 If you rename or remove a file, add it to [lib/redirects.js](lib/redirects.js) too keep
 things from breaking.
 
+## Sections
+
+If you rename a directory inside the `content` directory, you'll need to change it in [sections.json](/sections.json) to allow the [content.json](/content.json) to pick up the changes. 
+
 ## Development
 
 Download node at [nodejs.org](http://nodejs.org) and install it, if you haven't already.


### PR DESCRIPTION
I hit the problem during work on #393 and needed to figure out what to do to make the directory visible again, after initially trying to change the content.json directly, not realising that it was a built file at first.

So I thought I'd add that note to the docs.