### PR TITLE
Add readme publish note

### DIFF
--- a/content/getting-started/publishing-npm-packages.md
+++ b/content/getting-started/publishing-npm-packages.md
@@ -28,3 +28,5 @@ When you make changes, you can update the package using `npm version <update_typ
 After updating the version number, you can `npm publish` again.
 
 Test: Go to `http://npmjs.com/package/<package>`. The package number should be updated.
+
+The README displayed on the site will not be updated unless a new version of your package is published, so you would need to run `npm version patch` and `npm publish` to have a documentation fix displayed on the site.


### PR DESCRIPTION
Fixes #166.

I am not 100% sure of the intended information hierarchy here, but I thought that it made sense to add the note in `getting-started/publishing-npm-packages`.

EDIT: huh, seem to have picked up some commits from the 10th of September. No files changed though. Strange... Any ideas?