### PR TITLE
Improve accessibility of pre blocks

### DIFF
--- a/public/styles/index.styl
+++ b/public/styles/index.styl
@@ -96,8 +96,8 @@ pre code
   display block
   overflow-x auto
   padding 0.5em
-  color #333
-  background none repeat scroll 0% 0% #F8F8F8
+  color #F3F3F3
+  background none repeat scroll 0% 0% #444
   margin-top 15px
   margin-bottom 15px
 


### PR DESCRIPTION
During a pairing session with a co-worker (who has low visual acuity) it was pointed out that the `pre` blocks (while very important) were very difficult to distinguish from the surrounding text.

This pull-request fixes that issue by making them a dark grey (`#444`) and changing the font colour to an off-white (`#f3f3f3`). This then allows the `pre` block to be easily visually differentiated from the background of the page, and also allows in contained text to have a high contrast with the dark grey.

I realise this is a fairly large visual change to the docs (and therefore might not be acceptable!) but I thought I would suggest/implement it at least as a way of starting a discussion for improving the accessibility of the docs `pre` blocks.

To save some clicks, here is a screenshot:

![image](https://cloud.githubusercontent.com/assets/467683/10670312/e2010364-78dc-11e5-9145-52e20d88a97f.png)

<3