### PR TITLE
Fix red background on heading

### DIFF
--- a/content/company/private-npm.md
+++ b/content/company/private-npm.md
@@ -1,7 +1,5 @@
-<header>
-<h1>npm Private Modules</h1>
-<h2>Publish, share and install proprietary code easily</h2>
-</header>
+#npm Private Modules
+##Publish, share and install proprietary code easily
 
 Private modules are ordinary npm packages that only you, and people you select,
 can view, install, and publish. You publish them in your namespace or your team's namespace, just by giving them a name in package.json:


### PR DESCRIPTION
This fixes a red background issue that the headline had which was inherited from another header tag (the top red bar). It also replaces these tags with actual markdown headings.

<img width="1141" alt="screen shot 2015-10-28 at 3 41 07 pm" src="https://cloud.githubusercontent.com/assets/3066028/10801009/92ac8208-7d8b-11e5-9b01-74c513690eb6.png">