### PR TITLE
fix(CSS): add missing default body background color

### DIFF
--- a/public/styles/index.styl
+++ b/public/styles/index.styl
@@ -9,6 +9,7 @@
 
 body
   font-family fonts
+  background-color #fff
   color text-color
   margin 0
   padding 0


### PR DESCRIPTION
Hi

This way, people who have customized the default properties of their browser will be able to access the npm docs without problems.