### PR TITLE
shim Promise for node 10.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+if (typeof GLOBAL.Promise === 'undefined') GLOBAL.Promise = require('bluebird')
+
 var express = require('express')
 var hbs = require('hbs')
 var harp = require('harp')

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/npm/docs",
   "dependencies": {
     "@npm/policies": "git://github.com/npm/policies",
+    "bluebird": "^3.0.5",
     "cors": "^2.7.1",
     "express": "^4.13.3",
     "handlebars-helper-equal": "^1.0.0",


### PR DESCRIPTION
We accidentally broke production releasing docs, because docs is Node 0.10. This is a quick hot-fix to get us on our feet. @ceejbot is going to fix the box as soon as we're back from the holidays.