### PR TITLE
Makes Option 1 of "Fixing npm Permissions" a little more newbie-friendly

### DIFF
--- a/content/getting-started/fixing-npm-permissions.md
+++ b/content/getting-started/fixing-npm-permissions.md
@@ -16,6 +16,7 @@ You can fix this problem using one of two options:
 
 You should back-up your computer before moving forward.
 
+
 ## Option 1: Change the permission to npm's default directory
 
 1. Find the path to npm's directory:
@@ -24,13 +25,14 @@ You should back-up your computer before moving forward.
 
   For many systems, this will be `/usr/local`.
 
-  **WARNING**: If your path is `/usr`, switch to option 2.
+  **WARNING**: If the displayed path is *just* `/usr`, switch to [Option 2](#option-2-change-npm-s-default-directory-to-another-directory).
 
-2. Change the owner of npm's directory's to the effective name of the current user (your username!):
+2. Change the owner of npm's directories to the name of the current user (your username!):
 
-        sudo chown -R `whoami` <directory>
+        sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}
 
-  If you don't want to change the permissions on the entire directory, you can change permissions on the subfolders `lib/node_modules`, `bin`, and `share`.
+  This changes the permissions of the sub-folders used by npm and some other tools (`lib/node_modules`, `bin`, and `share`).
+
 
 ## Option 2: Change npm's default directory to another directory
 


### PR DESCRIPTION
The current guide I think may be making some assumptions about what newcomers know; they mightn't know:
* What a ` character is, instead of the usual apostrophe key.
* That `<directory>` is a way of indicating the that previous `/usr/local` path should be placed there.
* Whether or not changing all the permissions in `/usr/local` is a good thing, and why or how they would only change `lib/node_modules`, `bin` and `share`.