### PR TITLE
Don't reference `~` for .npmrc - closes #424

### DIFF
--- a/content/enterprise/github.md
+++ b/content/enterprise/github.md
@@ -36,13 +36,13 @@ To point npm On-Site at your GitHub Enterprise appliance:
 ## Logging in with two-factor authentication
 
 If you use two-factor authentication for your GitHub account, you will need to
-manually generate a token and add it to your `~/.npmrc` file.
+manually generate a token and add it to your [`.npmrc`](https://docs.npmjs.com/files/npmrc) file.
 
 1. Visit github.com/settings/tokens/new to create a new "Personal access token".
 1. Use a descriptive name for your token, like "myco npmE"
 1. Leave the default scopes as they are.
 1. Click "Generate Token" and you'll be redirected to a new page that displays your token. Copy the token right away, as it will only be displayed on screen once.
-1. Copy the token and paste it into the bottom of your `~/.npmrc` file:
+1. Copy the token and paste it into the bottom of your [`.npmrc`](https://docs.npmjs.com/files/npmrc) file:
 
 ```
 @myco:registry=https://npme-private.npmjs.com/

--- a/content/enterprise/intro.md
+++ b/content/enterprise/intro.md
@@ -121,7 +121,7 @@ Here's a quick video to help walk you through this process:
 
     The username, password, and email you use should respect the configured authentication strategy in your On-Site admin web console. If using the "Open" authentication strategy, any values will work.
 
-    Note that this will add content to your `~/.npmrc` file, similar to the following:
+    Note that this will add content to your [`.npmrc`](https://docs.npmjs.com/files/npmrc) file, similar to the following:
 
     ```
     @myco:registry=http://<your-server>:8080/
@@ -138,7 +138,7 @@ Here's a quick video to help walk you through this process:
     $ npm config set registry http://<your-server>:8080
     ```
 
-    This will add the following to your `~/.npmrc` file:
+    This will add the following to your [`.npmrc`](https://docs.npmjs.com/files/npmrc) file:
 
     ```
     registry=http://<your-server>:8080/

--- a/content/getting-started/scoped-packages.md
+++ b/content/getting-started/scoped-packages.md
@@ -45,7 +45,7 @@ If you use `npm init`, you can add your scope as an option to that command.
 npm init --scope=username
 ```
 
-If you use the same scope all the time, you will probably want to set this option in your `~/.npmrc` file.
+If you use the same scope all the time, you will probably want to set this option in your [`.npmrc`](https://docs.npmjs.com/files/npmrc) file.
 
 ```
 npm config set scope username

--- a/content/private-modules/ci-server-config.md
+++ b/content/private-modules/ci-server-config.md
@@ -5,11 +5,11 @@ featured: true
 
 # Downloading modules to CI/deployment servers
 
-If you are using deployment servers or testing with CI servers, you'll need a way to download your private modules to those servers. To do this, you can set up an `~/.npmrc` file which will authenticate your server with npm.
+If you are using deployment servers or testing with CI servers, you'll need a way to download your private modules to those servers. To do this, you can set up an [`.npmrc`](https://docs.npmjs.com/files/npmrc) file which will authenticate your server with npm.
 
 ## Getting an authentication token
 
-One of the things that has changed in npm is that we now use auth tokens to authenticate in the CLI. To generate an auth token, you can log in on any machine. You'll end up with a line in your `~/.npmrc` file that looks like this:
+One of the things that has changed in npm is that we now use auth tokens to authenticate in the CLI. To generate an auth token, you can log in on any machine. You'll end up with a line in your [`.npmrc`](https://docs.npmjs.com/files/npmrc) file that looks like this:
 
 ```
 //registry.npmjs.org/:_authToken=00000000-0000-0000-0000-000000000000
@@ -37,9 +37,9 @@ and then refresh your environment variables:
 source ~/.profile
 ```
 
-## Checking in your `~/.npmrc`
+## Checking in your `.npmrc`
 
-Then you can check in the `~/.npmrc` file, replacing your token with the environment variable.
+Then you can check in the [`.npmrc`](https://docs.npmjs.com/files/npmrc) file, replacing your token with the environment variable.
 
 ```
 //registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
`~` is a shell expansion not commonly available on Windows. To make
the sections of the docs talking about `.npmrc` more friendly to
Windows-users, remove references to `~` and add links to the npmrc doc
(which goes into more detail).

NOTE: Tested by running tests locally (tests passed) and checking the rendered docs (looks good to me)