### PR TITLE
Correct history, and my name

### DIFF
--- a/content/how-npm-works/npm2.md
+++ b/content/how-npm-works/npm2.md
@@ -43,7 +43,7 @@ can easily load both versions of the module in a way that they do
 not conflict with each other.
 
 How is it that npm and the node module loader are so wonderfully 
-symbiotic? They were both originally written by the same person,
-npm, Inc, CEO, Issac Schlueter. Like 2 sides of the same piece of 
+symbiotic? They were both written in large part by the same person,
+npm, Inc. CEO, Isaac Z. Schlueter. Like 2 sides of the same piece of 
 paper, npm and the Node.js module loader are what make Node.js
 a uniquely well-suited runtime for dependency management.


### PR DESCRIPTION
I like fame as much as the next CEO.  However, the facts of history are
such that it's very hard for me to take sole credit for 'originally'
writing the module system.

Prior to Node 0.4, npm 0.2 used to manage dependency hell with an nearly
equally hellish rats' nest of symbolic links and JavaScript shims.  As
long as all your `require()`s were on the first tick, it worked just
fine, but debugging was kind of a nightmare, and the abstraction leaked
more than anyone would've liked.

The module system itself (ie, `require` and `module` and `exports` and
such) is the main bit of "CommonJS" that has survived to our modern age
of JavaScript.  The most involved designers of that system, if I
remember correctly, where Kris Kowal, Kevin Dangoor, and Kris Zyp.  I
had a hand in writing the implementation in Node.js, but it was just
coding to a spec.  That module spec was originally called the
"securable module" specification, not because it was "secure" per se but
just that it could in theory _be_ secured, given an appropriately
sandboxed environment.  (NB: Node.js is not such an environment.  It is
insecure as all hell, but it's on the server side so you wrote that
code, so YOLO.)

A month or so before the release of node 0.4, Ryan ran into an issue
with node_redis, and tried to track down the bit of code that was
misbehaving, and stormed into my office at Joyent with a head full of
steam.  (Plain old software devs at Joyent had offices with closing
doors back in those days.  The SF office was still brand new.)

"This is unacceptable", he said.  "There has to be a way to not have
shims and symlinks all over the place."

He and I worked together to figure out a way that Node.js could meet the
requirements of avoiding dependency hell, without symlinks and shims,
and I wrote the implementation, which he carefully reviewed and landed.
(This was back when Node.js had exactly one committer.)  The result was
pretty close what we're left with today, minus a few clever performance
enhancements that have come along since.

So, I'm happy to be credited as a significant/primary author, but
"originally written" sounds like I did it all myself, which is
incorrect.

Also, correct the spelling of my first name :)