### PR TITLE
Use kramed instead of marky-markdown

### DIFF
--- a/content/getting-started/using-a-package.json.md
+++ b/content/getting-started/using-a-package.json.md
@@ -28,7 +28,7 @@ As a bare minimum, a `package.json` must have:
 
 For example:
 
-```
+```json
 {
   "name": "my-awesome-package",
   "version": "1.0.0"
@@ -132,14 +132,14 @@ For example: The project below uses any version of the package `my_dep` that mat
 major version 1 in production, and requires any version of the package `my_test_framework`
 that matches major version 3, but only for development:
 
-```
+```json
 {
   "name": "my_package",
   "version": "1.0.0",
   "dependencies": {
     "my_dep": "^1.0.0"
   },
-  "devDependencies" : {
+  "devDependencies": {
     "my_test_framework": "^3.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,11 +36,12 @@
     "handlebars-helper-equal": "^1.0.0",
     "harp": "^0.20.1",
     "hbs": "^4.0.0",
+    "highlight.js": "^9.0.0",
     "html-frontmatter": "^1.5.1",
     "js-beautify": "^1.5.10",
+    "kramed": "^0.5.5",
     "leven": "^1.0.1",
     "lodash": "^3.0.0",
-    "marky-markdown": "^5.4.0",
     "npm": "latest",
     "strftime": "^0.9.2",
     "walkdir": "0.0.11"


### PR DESCRIPTION
This removes the need to use oniguruma, which is a painful binary dep
that takes quite some time to install, and brings the markdown parsing a
little bit closer to GitHub flavoring.

A bit more work is needed to add CSS for the sytanx highlighting
classes, and another highlighter function might be worth trying out.

I figured we can use this as a little bit of a controlled test for how we might want to parse READMEs on the website.

Also, we should totally send Kramed a pull req to add sync syntax highlighting without having to jump through an arbitrary callback hoop. 