### PR TITLE
Add https scheme to all iframe URLs for embedded videos

### DIFF
--- a/content/getting-started/creating-node-modules.md
+++ b/content/getting-started/creating-node-modules.md
@@ -5,7 +5,7 @@ featured: true
 
 # Creating Node.js modules
 
-<iframe src="//www.youtube.com/embed/3I78ELjTzlQ" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/3I78ELjTzlQ" frameborder="0" allowfullscreen></iframe>
 
 Node.js modules are one kind of package which can be published to npm. When you create a new module, you want to start with the `package.json` file.
 

--- a/content/getting-started/fixing-npm-permissions.md
+++ b/content/getting-started/fixing-npm-permissions.md
@@ -5,11 +5,11 @@ featured: true
 
 # Fixing npm permissions
 
-<iframe src="//www.youtube.com/embed/bxvybxYFq2o" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/bxvybxYFq2o" frameborder="0" allowfullscreen></iframe>
 
 You may receive an `EACCES` error when you try to install a package globally. This indicates that you do not have permission to write to the directories that npm uses to store global packages and commands.
 
-You can fix this problem using one of two options: 
+You can fix this problem using one of two options:
 
 1. Change the permission to npm's default directory.
 1. Change npm's default directory to another directory.

--- a/content/getting-started/installing-node.md
+++ b/content/getting-started/installing-node.md
@@ -5,7 +5,7 @@ featured: true
 
 # Installing Node.js and updating npm
 
-<iframe src="//www.youtube.com/embed/wREima9e6vk" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/wREima9e6vk" frameborder="0" allowfullscreen></iframe>
 
 ## Installing Node.js
 

--- a/content/getting-started/installing-npm-packages-globally.md
+++ b/content/getting-started/installing-npm-packages-globally.md
@@ -5,7 +5,7 @@ featured: true
 
 # Installing npm packages globally
 
-<iframe src="//www.youtube.com/embed/JXi9pg5fsao" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/JXi9pg5fsao" frameborder="0" allowfullscreen></iframe>
 
 There are two ways to install npm packages: locally or globally. You choose which kind of installation to use based on how you want to use the package.
 

--- a/content/getting-started/installing-npm-packages-locally.md
+++ b/content/getting-started/installing-npm-packages-locally.md
@@ -5,7 +5,7 @@ featured: true
 
 # Installing npm packages locally
 
-<iframe src="//www.youtube.com/embed/JDSfqFFbNYQ" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/JDSfqFFbNYQ" frameborder="0" allowfullscreen></iframe>
 
 There are two ways to install npm packages: locally or globally. You choose which kind of
 installation to use based on how you want to use the package.
@@ -19,7 +19,7 @@ To learn more about the `install` command's behavior, check out the [CLI doc pag
 
 ## Installing
 
-A package can be downloaded with the command 
+A package can be downloaded with the command
 
 ```
 > npm install <package_name>
@@ -37,7 +37,7 @@ on Windows.
 
 #### Example:
 
-Install a package called `lodash`. Confirm that it ran successfully by listing the 
+Install a package called `lodash`. Confirm that it ran successfully by listing the
 contents of the `node_modules` directory and seeing a directory called `lodash`.
 
 ```

--- a/content/getting-started/publishing-npm-packages.md
+++ b/content/getting-started/publishing-npm-packages.md
@@ -5,7 +5,7 @@ featured: true
 
 # Publishing npm packages
 
-<iframe src="//www.youtube.com/embed/BkotrAFtBM0" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/BkotrAFtBM0" frameborder="0" allowfullscreen></iframe>
 
 You can publish any directory that has a `package.json` file, e.g. a [node module](/getting-started/creating-node-modules).
 

--- a/content/getting-started/semantic-versioning.md
+++ b/content/getting-started/semantic-versioning.md
@@ -5,7 +5,7 @@ featured: true
 
 # Semantic versioning and npm
 
-<iframe src="//www.youtube.com/embed/kK4Meix58R4" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/kK4Meix58R4" frameborder="0" allowfullscreen></iframe>
 
 Semantic versioning is a standard that a lot of projects use to communicate what kinds of changes are in this release. It's important to communicate what kinds of changes are in a release because sometimes those changes will break the code that depends on the package.
 

--- a/content/getting-started/uninstalling-global-packages.md
+++ b/content/getting-started/uninstalling-global-packages.md
@@ -5,7 +5,7 @@ featured: true
 
 # Uninstalling global packages
 
-<iframe src="//www.youtube.com/embed/XbvjZxUZJGg" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/XbvjZxUZJGg" frameborder="0" allowfullscreen></iframe>
 
 Global packages can be uninstalled with `npm uninstall -g <package>`:
 

--- a/content/getting-started/uninstalling-local-packages.md
+++ b/content/getting-started/uninstalling-local-packages.md
@@ -5,7 +5,7 @@ featured: true
 
 # Uninstalling local packages
 
-<iframe src="//www.youtube.com/embed/Z-BpYj6cSoQ" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/Z-BpYj6cSoQ" frameborder="0" allowfullscreen></iframe>
 
 You can remove a package from your node_modules directory using `npm uninstall <package>`:
 

--- a/content/getting-started/updating-local-packages.md
+++ b/content/getting-started/updating-local-packages.md
@@ -5,7 +5,7 @@ featured: true
 
 # Updating local packages
 
-<iframe src="//www.youtube.com/embed/HRudtPGcOt4" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/HRudtPGcOt4" frameborder="0" allowfullscreen></iframe>
 
 Every so often, you should update the packages you depend on so you can get any changes that have been made to code upstream.
 

--- a/content/private-modules/intro.md
+++ b/content/private-modules/intro.md
@@ -7,7 +7,7 @@ featured: true
 
 With npm private modules, you can use the npm registry to host your own private code and the npm command line to manage it. This makes it easy to use public modules like Express and Browserify side-by-side with your own private code.
 
-<iframe src="//www.youtube.com/embed/O6JoXGnHK_Y" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/O6JoXGnHK_Y" frameborder="0" allowfullscreen></iframe>
 
 ## Before we start
 


### PR DESCRIPTION
Fixes #505, which was based on [this comment](https://github.com/npm/docs/pull/467#discussion_r48486983).

Not super important since the schemeless URLs will use https if the docs site is served over https, which is forced in production.

Just trying to keep things consistent.

Note the removal of trailing whitespace is courtesy of Atom (and the lack of a `.editorconfig` file).