### PR TITLE
Clean up On-Site client configuration doc

### DIFF
--- a/content/enterprise/client-configuration.md
+++ b/content/enterprise/client-configuration.md
@@ -1,55 +1,87 @@
 <!--
 order: 4
-title: Configuring the client
+title: Configuring the CLI client
 featured: true
 -->
 
-# Configuring the client
+# Configuring the CLI client
 
-The client you use to interact with your npm On-Site server is the same client that you use with the public npm registry.
+The client you use to interact with your npm On-Site server is the same client
+that you use with the public npm registry.
 
 ## Install the latest npm client
 
-npm On-Site requires a 2.x or newer version of the npm client. You can get this by running
+npm On-Site requires a 2.x or newer version of the npm client. You can get this
+by running:
 
-```bash
+```
 [sudo] npm install npm -g
  ```
 
-## Pointing your client to the registry
+<a name="pointing-your-client-to-the-registry"></a>
+## Pointing your client to the On-Site registry
 
-Once you have an up-to-date client, you can configure it to install from and publish to your private npm On-Site registry.
+Once you have an up-to-date client, you can configure it to install from and
+publish to your private npm On-Site registry.
 
-### Using your private registry for all packages
+You can do this in one of two ways:
 
-If you want all packages, whether they are under a scope or not, to be stored in your private registry, then
-you should configure the npm client to use your private npm On-Site appliance as the top
-level registry. To do this, use the `--registry` flag without the `--@scope` flag.
+1. [Using On-Site for private _and public_ packages](#using-your-private-registry-for-all-packages)
+2. [Using On-Site for private packages only](#using-your-private-registry-for-your-scoped-packages)
 
-```bash
+Read about each option below.
+
+<a name="using-your-private-registry-for-all-packages"></a>
+### Option 1: Using On-Site for private and public packages
+
+If you want all packages, whether they are under a scope or not, to be stored in
+your private registry, then you should configure the npm client to use your
+private npm On-Site appliance as the top level registry.
+
+To do this, first set your On-Site registry as the CLI's default registry:
+
+```
+npm config set registry http://myreg.mycompany.com:8080
+```
+
+And then authenticate against your registry without a scope:
+
+```
 npm login --registry=http://myreg.mycompany.com:8080
 ```
 
-When clients are configured this way, they will always use your private npm On-Site registry as their main registry. When using `npm install`, it will only look in the private registry to find the package. This can lead to problems if you haven't mirrored all of the packages that your users need from the public registry.
+When clients are configured this way, they will always use your private npm
+On-Site registry as their main registry. When using `npm install`, it will only
+look in the private registry to find the package.
 
- To make life easier for your users, you can configure npm On-Site to automatically mirror a package from public registry when the user tries to install a package that is not yet mirrored. The package will also be added to the whitelist.
+To make sure your On-Site instance supports this functionality, you should
+enable the "Read Through Cache" setting (enabled by default) in the server's
+admin console (`https://myreg.mycompany.com:8800/settings`) so that public
+packages are automatically mirrored from the public registry and automatically
+added to your registry's whitelist.
 
- To do this, set `Read through cache` to `Yes` in the npm On-Site
- admin console (_http://myreg.mycompany.com:8800_)
+<a name="using-your-private-registry-for-your-scoped-packages"></a>
+### Option 2: Using On-Site for private packages only
 
-### Using your private registry for your scoped packages
+If you want to default to using the public npm registry for most packages and
+only use your private registry for packages under a particular scope, then you
+can specify that the registry should only be used for that scope.
 
-If you want to default to using the public npm registry for most packages and only use your private registry for packages under a particular scope, then you can specify that the registry should only be used for that scope.
+To do so, use `npm login` with a registry and scope:
 
-```bash
+```
 npm login --registry=http://myreg.mycompany.com:8080 --scope=@myco
 ```
 
 ## Logging in
 
-The `npm login` command will prompt you for your credentials. By default, these will be your GitHub or GitHub Enterprise credentials.
+The `npm login` command will prompt you for your credentials. The credentials
+you use should match the authentication strategy configured in the Settings of
+your instance's admin console (`https://myreg.mycompany.com:8800/settings`).
+**By default, these will be your GitHub or GitHub Enterprise credentials.**
 
-You should configure npm On-Site in the admin console to point to your
-GitHub Enterprise server. Read more about our [GitHub Enterprise Integration](/enterprise/github).
+For details on GitHub Enterprise integration, please see
+[this page](/enterprise/github).
 
-Read about how to configure custom authentication [here](/enterprise/custom-authentication).
+For details on configuring custom authentication, please see
+[this page](/enterprise/custom-authentication).


### PR DESCRIPTION
Prompted by the fact that the instructions for "Using your private registry for all packages" are incorrect - must make mention of the `npm config set registry http://private-registry:8080` command to be able to install public packages from the private registry without having to provide a `--registry` argument. Just authenticating against the registry without a scope is not enough.

The rest was just to try and clarify things or make them more consistent with other On-Site docs.

Note that I renamed headers but kept the old anchors so page-specific links in the wild are still valid.