### PR TITLE
clarify what's included in `npm publish`

### DIFF
--- a/content/getting-started/publishing-npm-packages.md
+++ b/content/getting-started/publishing-npm-packages.md
@@ -19,6 +19,8 @@ Test: Use `npm config ls` to ensure that the credentials are stored on your clie
 
 Use `npm publish` to publish the package.
 
+Note that everything in the directory will be included unless it is ignored by a local `.gitignore` or `.npmignore` file as described in [`npm-developers`](/misc/developers).
+
 Test: Go to `https://npmjs.com/package/<package>`. You should see the information for your new package.
 
 ## Updating the package


### PR DESCRIPTION
This page may be where many people first learn how to use `npm publish`, and as such I think it's important to let them know what will be included in the published package.

More background available in the CLI PR I made, npm/npm#11188.