### PR TITLE
Fixes #485 by indenting the second line of text

### DIFF
--- a/public/styles/index.styl
+++ b/public/styles/index.styl
@@ -2,7 +2,7 @@
 @import "_homepage"
 @import "_404"
 
-.button 
+.button
   color npmred
   text-decoration underline
 
@@ -241,6 +241,9 @@ ul.pageColumns
   a
     text-decoration none
     font-weight 600
+    padding-left 32px
+    text-indent -32px
+    display inline-block
     &:hover
       text-decoration underline
   span


### PR DESCRIPTION
This solution solves the problem by indenting the second line of text
(and beyond).  This is a pure-CSS solution, which should be preferrable
to a solution in JS.

This is not necessarily the requested solution, but it looks clean and
solves the problem in a simple way.

Tested other screen sizes and looks good in all sizes.