### PR TITLE
#622 clarify `--save` vs `--save-dev` when uninstalling

### DIFF
--- a/content/getting-started/uninstalling-local-packages.md
+++ b/content/getting-started/uninstalling-local-packages.md
@@ -18,3 +18,11 @@ To remove it from the dependencies in `package.json`, you will need to use the s
 ```
 npm uninstall --save lodash
 ```
+
+To remove it from the dev dependencies in `package.json`, you will need to use the save-dev flag:
+
+```
+npm uninstall --save-dev lodash
+```
+
+NOTE: If the package is in both the dependencies and the dev dependencies, you will need to run command twice, each with the different option shown above.


### PR DESCRIPTION
Add additional sample for uninstalling packages for --save-dev flag.
Add note to point out that --save and --save-dev are independent.