### PR TITLE
Make version update command same as one in site footer

### DIFF
--- a/content/getting-started/installing-node.md
+++ b/content/getting-started/installing-node.md
@@ -18,7 +18,7 @@ Test: Run `node -v`. The version should be higher than v0.10.32.
 
 Node comes with npm installed so you should have a version of npm. However, npm gets updated more frequently than Node does, so you'll want to make sure it's the latest version.
 
-`npm install npm -g`
+`npm install npm@latest -g`
 
 Test: Run `npm -v`. The version should be higher than 2.1.8.
 


### PR DESCRIPTION
Getting started guide recommends `npm install npm -g`, instead of `npm install npm@latest -g` for the latest version which is what the guide is aiming at.