### PR TITLE
Reorder pages in All Docs to follow section ordering

### DIFF
--- a/bin/tree.js
+++ b/bin/tree.js
@@ -103,9 +103,17 @@ emitter.on('file', function (filepath, stat) {
 })
 
 emitter.on('end', function () {
-  content.pages = _.sortBy(content.pages, function (page) {
-    return page.title.toLowerCase()
-  })
+  // Get the ids for each section
+  var sectionIds = _.map(content.sections, 'id')
+
+  content.pages = _.sortBy(content.pages, [
+    function (page) {
+      return sectionIds.indexOf(page.section)
+    },
+    function (page) {
+      return page.title.toLowerCase()
+    }
+  ])
 
   fs.writeFileSync(contentFile, JSON.stringify(content, null, 2))
   console.log('Wrote %s', path.relative(process.cwd(), contentFile))


### PR DESCRIPTION
Adds a new function in the lodash `sortBy` iteratees, so that the
first sorting pass matches the order of the sections as laid out
in `sections.json`.

Fixes #716 