### PR TITLE
Fix docs for `npm init --yes`

### DIFF
--- a/content/getting-started/using-a-package.json.md
+++ b/content/getting-started/using-a-package.json.md
@@ -61,7 +61,7 @@ or `-y` flag:
 > npm init --yes
 ```
 
-This will ask you only one question, `author`. Otherwise it will fill in default
+This will not ask you any questions, and will fill in the default
 values: 
 
 ```
@@ -70,13 +70,14 @@ Wrote to /home/ag_dubs/my_package/package.json:
 
 {
   "name": "my_package",
+  "description": "",
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
-  "author": "ag_dubs",
+  "author": "",
   "license": "ISC",
   "repository": {
     "type": "git",
@@ -90,12 +91,13 @@ Wrote to /home/ag_dubs/my_package/package.json:
 ```
 
 - `name`: defaults to author name unless in a `git` directory, in which case it
-    will be the name of the repository
+    will be the name of the directory
+- `description`: empty
 - `version`: always `1.0.0`
 - `main`: always `index.js`
 - `scripts`: by default creates a empty `test` script
 - `keywords`: empty
-- `author`: whatever you provided the CLI
+- `author`: empty
 - `license`: [`ISC`][2]
 - `repository`: will pull in info from the current directory, if present
 - `bugs`: will pull in info from the current directory, if present


### PR DESCRIPTION
Fixes #650

I've updated Chapter 5 of the Getting Started guide with what npm seems to for `npm init --yes`. Briefly:

- `npm init --yes` does not ask for author, it just leaves it blank
- the default name in a non-git directory is directory name, not author name
- it also adds a empty description

Any feedback would be appreciated, thanks!