### PR TITLE
fix instance of tl;dr in COC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,7 +11,7 @@ friendly, safe, and accepting; free from intimidation or harassment.
 Towards this end, certain behaviors and practices will not be
 tolerated.
 
-## tl;dr
+## In Summary
 
 * Be respectful.
 * We're here to help: <abuse@npmjs.com>


### PR DESCRIPTION
Following on from #775.

Changes 'tl;dr' in the Code of Conduct to 'In Summary'. I felt this was better than 'Quick Summary' for a COC because I don't want your reading of a COC to be quick or haphazard.

With https://github.com/npm/docs/pull/775#issuecomment-263793149 in mind, let's discuss this!

🌟 Have a lovely day 🌟 