### PR TITLE
Remove unlinked reference in team docs

### DIFF
--- a/content/orgs/teams.md
+++ b/content/orgs/teams.md
@@ -45,7 +45,7 @@ teams in your Organization. You can do that by typing:
 > npm team ls <org>
 ```
 
-or by visiting the [Organization Dashboard] in the [web interface].
+or by visiting the [Organization Dashboard] in the web interface.
 
 ## Adding Users to a Team
 


### PR DESCRIPTION
There doesn't seem to be a link for this, so it comes out as `in the [web interface]` in the rendered page.