### PR TITLE
DELETE full-pages references from sections in content.lite.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,12 @@ content.sections.forEach(function (section) {
 })
 
 var lite = merge({}, content)
+lite.sections = lite.sections.map(function (section) {
+  section.pages = section.pages.map(function (page) {
+    return page.href
+  })
+  return section
+})
 lite.pages = lite.pages.map(function (page) {
   delete page.content
   return page


### PR DESCRIPTION
Deleting the full reference and only listing a href,
still allows for retrieving the short page info,
but reduces the size from 600+kb to 67kb.