### PR TITLE
lowercase 'global' to remove NodeJS DeprecationWarning

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-if (typeof GLOBAL.Promise === 'undefined') GLOBAL.Promise = require('bluebird')
+if (typeof global.Promise === 'undefined') global.Promise = require('bluebird')
 
 var express = require('express')
 var hbs = require('hbs')


### PR DESCRIPTION
CHANGE global to lowercase to remove deprecation message in newer NodeJS:

I get this message in my terminal when running the application:
```
(node:37224) DeprecationWarning: 'GLOBAL' is deprecated, use 'global'
```

This PR fixes that message