### PR TITLE
Correction for using the NPM_CONFIG_PREFIX

### DIFF
--- a/content/getting-started/fixing-npm-permissions.md
+++ b/content/getting-started/fixing-npm-permissions.md
@@ -60,7 +60,7 @@ Test: Download a package globally without using `sudo`.
 
         npm install -g jshint
 
-Instead of steps 2-4 you can also use the corresponding ENV variable (e.g. if you don't want to modify `~/.profile`):
+Instead of steps 3 and 4 you can also use the corresponding ENV variable (e.g. if you don't want to modify `~/.profile`):
 
         NPM_CONFIG_PREFIX=~/.npm-global
         


### PR DESCRIPTION
If using the NPM_CONFIG_PREFIX, one must still run step 2 so that NPM knows to use the .npm-global directory.