### PR TITLE
Use $HOME, not ~

### DIFF
--- a/content/getting-started/fixing-npm-permissions.md
+++ b/content/getting-started/fixing-npm-permissions.md
@@ -50,7 +50,7 @@ Instead, you can configure npm to use a different directory altogether. In our c
 
 3. Open or create a `~/.profile` file and add this line:
 
-        export PATH=~/.npm-global/bin:$PATH
+        export PATH=$HOME/.npm-global/bin:$PATH
 
 4. Back on the command line, update your system variables:
 


### PR DESCRIPTION
~ is a bash symbol, but also a valid path character. Unless explicitly evaluated to the user's home directory, the PATH addition is useless for everything except the user's shell, which means any non-bash program the user runs does not benefit from the global node programs installed. Using `$HOME` evaluates during sourcing of the user's `~/.profile` file, so the full, indisputable path is added for all programs to enjoy.

Source issue: https://github.com/driftyco/ionic-cli/issues/2214