### PR TITLE
Tweaking instructions in fixing-npm-permissions.md that could cause permanent system damage if copy/pasted in isolation

### DIFF
--- a/content/getting-started/fixing-npm-permissions.md
+++ b/content/getting-started/fixing-npm-permissions.md
@@ -29,7 +29,7 @@ You should back-up your computer before moving forward.
 
 2. Change the owner of npm's directories to the name of the current user (your username!):
 
-        sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}
+        sudo chown -R $(whoami) YOUR_NPM_PREFIX/{lib/node_modules,bin,share}
 
     This changes the permissions of the sub-folders used by npm and some other tools (`lib/node_modules`, `bin`, and `share`).
 


### PR DESCRIPTION
This removes bash command substitution so if the user hasn't read the step before (including the warning) like I and several others did then copy pasting the command won't destroy their computer's permissions - this fixes #745

IMO the small inconvenience is worth it - I was never able to get my computer working 100% properly after and finally chose to reinstall to get it back to normal.