### PR TITLE
Add security warning to docker-and-private-modules

### DIFF
--- a/content/private-modules/docker-and-private-modules.md
+++ b/content/private-modules/docker-and-private-modules.md
@@ -76,4 +76,6 @@ docker build --build-arg NPM_TOKEN=${NPM_TOKEN} .
 
 This will take your current `NPM_TOKEN` environment variable, and will build the docker image using it, so you can run `npm install` inside your container as the current logged in user!
 
-Note: Even if you delete the `.npmrc` file, it'll be kept in the commit history - to clean your secret up entirely make sure to squash them.
+## Security Warning
+
+Build arguments are visble in the docker history so ensure that you invalidate the npm token after building the image.   You can invalidate the token by logging out.


### PR DESCRIPTION
- remove squash tip: it doesn't do much good to remove the token from the layers when it's still visible in the history
- add warning that token stays present, recommend invalidating token