### PR TITLE
Fix typo in using-two-factor-authentication. QVR -> QR

### DIFF
--- a/content/getting-started/using-two-factor-authentication.md
+++ b/content/getting-started/using-two-factor-authentication.md
@@ -7,7 +7,7 @@ featured: true
 
 To meet the increasing need for strong digital security, npm has introduced two-factor authentication (2FA) to profiles and tokens. 2FA prevents unauthorized access to your accounts and projects. You have probably used 2FA before. For example, if you need to provide a code from your phone in addition to logging in with a password to access your bank account, your bank has enabled 2FA. Two-factor means that there are two pathways you must use to gain access to code or an account. 2FA would also include having a card key to get into a building, plus a physical key to get into an office. If you had one without the other, you could not get into the office.
 
-To get started using 2FA with npm you will need to have an authentication package that can provide the second authentication factor. If you don't have one, please download a product such as [Authy](https://authy.com/download/) or [Google Authenticator](https://support.google.com/accounts/answer/1066447). 
+To get started using 2FA with npm you will need to have an authentication package that can provide the second authentication factor. If you don't have one, please download a product such as [Authy](https://authy.com/download/) or [Google Authenticator](https://support.google.com/accounts/answer/1066447).
 
 (Note: npm will not use SMS (text-to-phone) as a method for authenticating users.)
 
@@ -91,7 +91,7 @@ The first step toward greater security is to add 2FA to your profile. This will 
 
 3.  When prompted, enter your npm password.
 
-4.  npm will present a QVR code with this message:
+4.  npm will present a QR code with this message:
 
     ````
     Scan into your authenticator app or enter code [**your code**]


### PR DESCRIPTION
Missed this when doing #877. Just a simple typo, sorted now 🙂 