### PR TITLE
Update using-a-package.json.md

### DIFF
--- a/content/getting-started/using-a-package.json.md
+++ b/content/getting-started/using-a-package.json.md
@@ -181,16 +181,16 @@ that matches major version 3, but only for development:
 }
 ```
 
-### The `--save` and `--save-dev` install flags
+### The `--save-prod` and `--save-dev` install flags
 
 The easier (and more awesome) way to add dependencies to your `package.json` is to do
-so from the command line, flagging the `npm install` command with either `--save` or
+so from the command line, flagging the `npm install` command with either `--save-prod` (assumed by default) or
 `--save-dev`, depending on how you'd like to use that dependency.
 
 To add an entry to your `package.json`'s `dependencies`:
 
 ```
-npm install <package_name> --save
+npm install <package_name> [--save-prod]
 ```
 
 To add an entry to your `package.json`'s `devDependencies`:


### PR DESCRIPTION
Updates the 'install flags' section for `--save` being inferred as default behaviour and renamed to `--save-prod`.