### PR TITLE
Fix typo

### DIFF
--- a/content/getting-started/installing-npm-packages-globally.md
+++ b/content/getting-started/installing-npm-packages-globally.md
@@ -7,7 +7,7 @@ featured: true
 
 There are two ways to install npm packages: locally or globally. You choose which kind of installation to use based on how you want to use the package.
 
-* If you want to use it a package as a command line tool, something like the grunt CLI, then you want to install it globally. This way, it works no matter which directory is your current directory. 
+* If you want to use the package as a command line tool, something like the grunt CLI, then you want to install it globally. This way, it works no matter which directory is your current directory. 
 
 * If you want to depend on the package from your own module using something like Node's `require`, then you want to install [locally](https://docs.npmjs.com/getting-started/installing-npm-packages-locally).
 


### PR DESCRIPTION
Change "it a package" to "the package", which both removes an extra word and makes it consistent with the next list item.