### PR TITLE
removed how npm works and policy

### DIFF
--- a/sections.json
+++ b/sections.json
@@ -2,9 +2,6 @@
   "id": "getting-started",
   "title": "Getting Started"
 }, {
-  "id": "how-npm-works",
-  "title": "How npm works"
-}, {
   "id": "private-modules",
   "title": "Private Modules"
 }, {
@@ -19,9 +16,6 @@
 }, {
   "id": "files",
   "title": "Configuring npm"
-}, {
-  "id": "policies",
-  "title": "npm policy documents"
 }, {
   "id": "company",
   "title": "npm, the Company",


### PR DESCRIPTION
This is to get rid of the no-longer valid "how npm works" and also to remove the Policy document as it did not make sense to maintain it two places. 