### PR TITLE
wrong URL

### DIFF
--- a/content/troubleshooting/if-your-npm-is-broken.md
+++ b/content/troubleshooting/if-your-npm-is-broken.md
@@ -8,7 +8,7 @@ featured: true
 Reinstall npm:
 
 ```sh
-curl -L https://www.npmjs.org/install.sh | sh
+curl -L https://npmjs.org/install.sh | sh
 ```
 
 If you're on Windows and you have a broken installation, the easiest thing to do is to reinstall node from the official installer (remember [this note](https://docs.npmjs.com/troubleshooting/try-the-latest-stable-version-of-npm#upgrading-on-windows)).


### PR DESCRIPTION
```
curl -L https://www.npmjs.org/install.sh | sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:29 --:--:--     0curl: (6) Could not resolve host: www.npmjs.org
```

while npmjs.org works fine.