### PR TITLE
Update broken link in package.json docs

### DIFF
--- a/content/getting-started/using-a-package.json.md
+++ b/content/getting-started/using-a-package.json.md
@@ -208,6 +208,6 @@ To understand more about the power of package.json, see the video "Installing np
 
 To learn more about semantic versioning, see [Getting Started "Semver" page][1].
 
-[1]: docs.npmjs.com/getting-started/semantic-versioning
+[1]: https://docs.npmjs.com/getting-started/semantic-versioning
 [2]: https://opensource.org/licenses/ISC
 


### PR DESCRIPTION
In the built version of the website, the link resolves to `https://docs.npmjs.com/getting-started/docs.npmjs.com/getting-started/semantic-versioning` instead of what it should be. 