### PR TITLE
Fixed broken Links for semver

### DIFF
--- a/content/getting-started/using-a-package.json.md
+++ b/content/getting-started/using-a-package.json.md
@@ -26,7 +26,7 @@ A `package.json` must have:
   - dashes and underscores allowed
 - `"version"`
   - in the form of `x.x.x`
-  - follows [semver spec](https://docs.npmjs.com/getting-started/semantic-versioning)
+  - follows [semver spec][1]
 
 For example:
 
@@ -208,6 +208,6 @@ To understand more about the power of package.json, see the video "Installing np
 
 To learn more about semantic versioning, see [Getting Started "Semver" page][1].
 
-[1]: docs.npmjs.com/getting-started/semantic-versioning
+[1]: https://docs.npmjs.com/getting-started/semantic-versioning
 [2]: https://opensource.org/licenses/ISC
 


### PR DESCRIPTION
Just adding the https ref link so the link routes correctly. Also, changed semver link in working with... to use reference.