### PR TITLE
Update using-a-package.json.md URL and Text

### DIFF
--- a/content/getting-started/using-a-package.json.md
+++ b/content/getting-started/using-a-package.json.md
@@ -204,7 +204,7 @@ If you have a `package.json` file in your directory and you run `npm install`, n
 
 ## Learn More 
 
-To understand more about the power of package.json, see the video "Installing npm packages locally" which you can find in [Chapter 8](https://docs.npmjs.com/getting-started/installing-npm-packages-globally). 
+To understand more about the power of package.json, see the video "Installing npm packages locally" which you can find in [Chapter 4](https://docs.npmjs.com/getting-started/installing-npm-packages-locally). 
 
 To learn more about semantic versioning, see [Getting Started "Semver" page][1].
 


### PR DESCRIPTION
The "Learn More" text refers to "Installing npm packages locally," and refers to  a page with a video about this. It says this information can be found in "Chapter 8," linked as https://docs.npmjs.com/getting-started/installing-npm-packages-globally, however this chapter is titled "Installing NPM Packages Globally," so I believe this is the wrong chapter and link. Also, there's no video.

In this PR I've updated the text to refer to Chapter 4, "How to Install Local Packages," which seems to be the intended target due to title as well as the fact that it has a video. The link has been updated to https://docs.npmjs.com/getting-started/installing-npm-packages-locally