### PR TITLE
change the word "dashes" to "hyphens"

### DIFF
--- a/content/getting-started/using-a-package.json.md
+++ b/content/getting-started/using-a-package.json.md
@@ -23,7 +23,7 @@ A `package.json` must have:
 - `"name"`
   - all lowercase
   - one word, no spaces
-  - dashes and underscores allowed
+  - hyphens and underscores allowed
 - `"version"`
   - in the form of `x.x.x`
   - follows [semver spec](https://docs.npmjs.com/getting-started/semantic-versioning)


### PR DESCRIPTION
I believe the proper word to use is "hyphen", which refers to U+002D HYPHEN-MINUS, *-*. This is the key at the top of standard keyboards. Whereas "dash" commonly refers to U+2014 EM DASH, *—* (and in some cases U+2013 EN DASH, *–*), which aren’t allowed in package names.