### PR TITLE
Add docs for new audit and report commands

### DIFF
--- a/content/getting-started/about-audit-reports.md
+++ b/content/getting-started/about-audit-reports.md
@@ -1,0 +1,51 @@
+<!--
+title: 22 - About audit reports
+featured: true
+-->
+
+# About audit reports
+
+Audit reports contain information about security vulnerabilities in your project's dependencies to help you fix the vulnerability or troubleshoot further.
+
+* [Severity](#severity)
+* [Description](#description)
+* [Package](#package)
+* [Patched in](#patched-in)
+* [Dependency of](#dependency-of)
+* [Path](#path)
+* [More info](#more-info)
+
+## Severity
+
+The severity of the vulnerability, determined by the impact and exploitability of the vulnerability in its most common use case.
+
+| Severity |  Recommended action |
+|----------|---------------------|
+| Critical | Address immediately |
+| High | Address as quickly as possible |
+| Moderate | Address as time allows |
+| Low | Address at your discretion |
+
+## Description
+
+The description of the vulnerability. For example, "Denial of service".
+
+## Package
+
+The name of the package that contains the vulnerability.
+
+## Patched in
+
+The semver range that describes what versions contain a fix for the vulnerability.
+
+## Dependency of
+
+The module that the package with the vulnerability depends on.
+
+## Path
+
+The path to the code that contains the vulnerability.
+
+## More info
+
+A link to the security report.

--- a/content/getting-started/running-a-security-audit.md
+++ b/content/getting-started/running-a-security-audit.md
@@ -1,0 +1,155 @@
+<!--
+title: 21 - How to run a security audit
+featured: true
+-->
+
+# About security audits
+
+A security audit is an assessment of package dependencies for security vulnerabilities. Security audits help you protect your package's users by enabling you to find and fix known vulnerabilities in dependencies that could cause data loss, service outages, unauthorized access to sensitive information, or other issues.
+
+# Running a security audit with `npm audit`
+
+**Note: The `npm audit` command is available in npm@6. To upgrade, run `npm install npm@latest -g`.**
+
+The <a href="https://docs.npmjs.com/cli/audit">`npm audit`</a> command submits a description of the dependencies configured in your package to your default registry and asks for a report of known vulnerabilities.
+
+`npm audit` automatically runs when you install a package with `npm install`. You can also run `npm audit` manually on your [locally installed packages](https://docs.npmjs.com/getting-started/installing-npm-packages-locally) to conduct a security audit of the package and produce a report of dependency vulnerabilities and, if available, suggested patches.
+
+1. On the command line, navigate to your package directory by typing `cd path/to/your-package-name` and pressing **Enter**.
+2. Ensure your package contains `package.json` and `package-lock.json` files.
+3. Type `npm audit` and press **Enter**.
+4. Review the audit report and run recommended commands or investigate further if needed.
+
+## Resolving `EAUDITNOPJSON` and `EAUDITNOLOCK` errors
+
+`npm audit` requires packages to have `package.json` and `package-lock.json` files.
+
+* If you get an `EAUDITNOPJSON` error, create a `package.json` file by following the steps in "[Working with package.json](https://docs.npmjs.com/getting-started/using-a-package.json)".
+* If you get an `EAUDITNOLOCK` error, make sure your package has a `package.json` file, then create the package lock file by running `npm i --package-lock-only`.
+
+# Reviewing and acting on the security audit report
+
+Running `npm audit` will produce a report of security vulnerabilities with the affected package name, vulnerability severity and description, path, and other information, and, if available, commands to apply patches to resolve vulnerabilities. For more information on the fields in the audit report, see "[About audit reports](https://npmjs.com/docs/getting-started/about-audit-reports)"
+
+## Security vulnerabilities found with suggested patches
+
+If security vulnerabilities are found and patches are available, run the recommended commands to apply the patches to your installed dependencies.
+
+```
+# Run  npm install helmet@3.12.0  to resolve 2 vulnerabilities
+┌───────────────┬──────────────────────────────────────────────────────────────┐
+│ low           │ Regular Expression Denial of Service                         │
+├───────────────┼──────────────────────────────────────────────────────────────┤
+│ Package       │ debug                                                        │
+├───────────────┼──────────────────────────────────────────────────────────────┤
+│ Dependency of │ helmet                                                       │
+├───────────────┼──────────────────────────────────────────────────────────────┤
+│ Path          │ helmet > connect > debug                                     │
+├───────────────┼──────────────────────────────────────────────────────────────┤
+│ More info     │ https://nodesecurity.io/advisories/534                       │
+└───────────────┴──────────────────────────────────────────────────────────────┘
+┌───────────────┬──────────────────────────────────────────────────────────────┐
+│ low           │ Regular Expression Denial of Service                         │
+├───────────────┼──────────────────────────────────────────────────────────────┤
+│ Package       │ debug                                                        │
+├───────────────┼──────────────────────────────────────────────────────────────┤
+│ Dependency of │ helmet                                                       │
+├───────────────┼──────────────────────────────────────────────────────────────┤
+│ Path          │ helmet > connect > finalhandler > debug                      │
+├───────────────┼──────────────────────────────────────────────────────────────┤
+│ More info     │ https://nodesecurity.io/advisories/534                       │
+└───────────────┴──────────────────────────────────────────────────────────────┘
+
+[!] 2 vulnerabilities found - Packages audited: 918 (466 dev, 87 optional)
+    Severity: 2 Low
+```
+
+### SEMVER warnings
+
+If the recommended action is a potential breaking change (semantic version major change), it will be followed by a SEMVER WARNING. If the package with the vulnerability has changed its API, you may need to make additional changes to your package's code.
+
+```
+SEMVER WARNING: Recommended action is a potentially breaking change
+```
+
+## Security vulnerabilities found requiring manual review
+
+If security vulnerabilities are found, but no patches are available, the audit report will provide information about the vulnerability so you can investigate further.
+
+```
+┌───────────────┬──────────────────────────────────────────────────────────────┐
+│ high          │ Denial of Service                                            │
+├───────────────┼──────────────────────────────────────────────────────────────┤
+│ Package       │ foo                                                          │
+├───────────────┼──────────────────────────────────────────────────────────────┤
+│ Patched in    │ No patch available                                           │
+├───────────────┼──────────────────────────────────────────────────────────────┤
+│ Dependency of │ @npm/spife                                                   │
+├───────────────┼──────────────────────────────────────────────────────────────┤
+│ Path          │ @npm/spife > numbat-process > numbat-emitter > foo           │
+├───────────────┼──────────────────────────────────────────────────────────────┤
+│ More info     │ https://nodesecurity.io/advisories/550                       │
+└───────────────┴──────────────────────────────────────────────────────────────┘
+```
+
+To address the vulnerability, you can
+
+* [Check for mitigating factors](#check-for-mitigating-factors)
+* [Update dependent packages if a fix exists](#update-dependent-packages-if-a-fix-exists)
+* [Fix the vulnerability](#fix-the-vulnerability)
+* [Open an issue in the package or dependent package issue tracker](#open-an-issue-in-the-package-or-dependent-package-issue-tracker)
+
+### Check for mitigating factors
+
+Review the security advisory in the "More info" field for mitigating factors that may allow you to continue using the package with the vulnerability in limited cases. For example, the vulnerability may only exist when the code is used on specific operating systems, or when a specific function is called.
+
+### Update dependent packages if a fix exists
+
+If a fix exists but packages that depend on the package with the vulnerability have not been updated to include the fixed version, you may want to open a pull or merge request on the dependent package repository to use the fixed version.
+
+1. To find the package that must be updated, check the "Path" field for the location of the package with the vulnerability, then check for the package that depends on it. For example, if the path to the vulnerability is `@package-name > dependent-package > package-with-vulnerability`, you will need to update `dependent-package`.
+2. On the [npm public registry](https://npmjs.com), find the dependent package and navigate to its repository. For more information on finding packages, see "[How to find and select packages](https://docs.npmjs.com/getting-started/searching-for-packages)".
+3. In the dependent package repository, open a pull or merge request to update the version of the vulnerable package to a version with a fix.
+4. Once the pull or merge request is merged and the package has been updated in the [npm public registry](https://npmjs.com), update your copy of the package with `npm update`.
+
+### Fix the vulnerability
+
+If a fix does not exist, you may want to suggest changes that address the vulnerability to the package maintainer in a pull or merge request on the package repository.
+
+1. Check the "Path" field for the location of the vulnerability.
+2. On the [npm public registry](https://npmjs.com), find the package with the vulnerability. For more information on finding packages, see "[How to find and select packages](https://docs.npmjs.com/getting-started/searching-for-packages)".
+3. In the package repository, open a pull or merge request to make the fix on the package repository.
+4. Once the fix is merged and the package has been updated in the npm public registry, update your copy of the package that depends on the package with the fix.
+
+### Open an issue in the package or dependent package issue tracker
+
+If you do not want to fix the vulnerability or update the dependent package yourself, open an issue in the package or dependent package issue tracker.
+
+1. On the [npm public registry](https://npmjs.com), find the package with the vulnerability or the dependent package that needs an update. For more information on finding packages, see "[How to find and select packages](https://docs.npmjs.com/getting-started/searching-for-packages)".
+2. In the package or dependent package issue tracker, open an issue and include information from the audit report, including the vulnerability report from the "More info" field.
+
+## No security vulnerabilities found
+
+If no security vulnerabilities are found, this means that packages with known vulnerabilities were not found in your package dependency tree. Since the advisory database can be updated at any time, we recommend regularly running `npm audit` manually, or adding `npm audit` to your continuous integration process.
+
+```
+[+] no known vulnerabilities found [30 packages audited]
+```
+
+# Turning off `npm audit` on package installation
+
+## Installing a single package
+
+To turn off `npm audit` when installing a single package, use the `--no-audit` flag:
+
+`npm install example-package-name --no-audit`
+
+For more information, see the [npm-install command](https://docs.npmjs.com/cli/install).
+
+## Installing all packages
+
+To turn off `npm audit` when installing all packages, set the `audit` setting to `false` in your user and global npmrc config files:
+
+`npm set audit false`
+
+For more information, see the [npm-config management command](https://docs.npmjs.com/cli/config) and the [npm-config audit setting](https://docs.npmjs.com/misc/config#audit).

--- a/content/getting-started/running-a-security-audit.md
+++ b/content/getting-started/running-a-security-audit.md
@@ -1,5 +1,5 @@
 <!--
-title: 21 - How to run a security audit
+title: 21 - How to run a security audit with npm audit
 featured: true
 -->
 


### PR DESCRIPTION
This PR adds: 

* A new conceptual and procedural article about running a security audit with `npm audit`
* A new reference article about the fields in an audit report