### PR TITLE
fix incorrect link to edit docs on GitHub

### DIFF
--- a/bin/tree.js
+++ b/bin/tree.js
@@ -85,9 +85,9 @@ emitter.on('file', function (filepath, stat) {
   if (['cli', 'files', 'misc'].indexOf(page.section) > -1) {
     page.edit_url = 'https://github.com/npm/npm/edit/latest/doc/' + page.filename
   } else if (page.section === 'policies') {
-    page.edit_url = 'https://github.com/npm/policies/edit/latest/' + path.basename(page.filename)
+    page.edit_url = 'https://github.com/npm/policies/master/latest/' + path.basename(page.filename)
   } else if (page.section) {
-    page.edit_url = 'https://github.com/npm/docs/edit/latest/content/' + page.filename
+    page.edit_url = 'https://github.com/npm/docs/edit/master/content/' + page.filename
   }
 
   page.href = '/' + page.filename

--- a/bin/tree.js
+++ b/bin/tree.js
@@ -37,7 +37,7 @@ emitter.on('file', function (filepath, stat) {
     filename: filepath.replace(/.*\/content\//, ''),
     modified: null,
     modifiedPretty: null,
-    edit_url: 'https://github.com/npm/npm/edit/master/doc/cli/npm-bugs.md',
+    edit_url: 'https://github.com/npm/npm/edit/latest/doc/cli/npm-bugs.md',
     content: fs.readFileSync(filepath, 'utf-8')
   }
 
@@ -83,11 +83,11 @@ emitter.on('file', function (filepath, stat) {
 
   // In what repository does this doc live?
   if (['cli', 'files', 'misc'].indexOf(page.section) > -1) {
-    page.edit_url = 'https://github.com/npm/npm/edit/master/doc/' + page.filename
+    page.edit_url = 'https://github.com/npm/npm/edit/latest/doc/' + page.filename
   } else if (page.section === 'policies') {
-    page.edit_url = 'https://github.com/npm/policies/edit/master/' + path.basename(page.filename)
+    page.edit_url = 'https://github.com/npm/policies/edit/latest/' + path.basename(page.filename)
   } else if (page.section) {
-    page.edit_url = 'https://github.com/npm/docs/edit/master/content/' + page.filename
+    page.edit_url = 'https://github.com/npm/docs/edit/latest/content/' + page.filename
   }
 
   page.href = '/' + page.filename

--- a/bin/tree.js
+++ b/bin/tree.js
@@ -85,7 +85,7 @@ emitter.on('file', function (filepath, stat) {
   if (['cli', 'files', 'misc'].indexOf(page.section) > -1) {
     page.edit_url = 'https://github.com/npm/npm/edit/latest/doc/' + page.filename
   } else if (page.section === 'policies') {
-    page.edit_url = 'https://github.com/npm/policies/master/latest/' + path.basename(page.filename)
+    page.edit_url = 'https://github.com/npm/policies/edit/master/' + path.basename(page.filename)
   } else if (page.section) {
     page.edit_url = 'https://github.com/npm/docs/edit/master/content/' + page.filename
   }


### PR DESCRIPTION
Paths such as https://github.com/npm/npm/edit/master/doc/cli/npm-bugs.md do not exist any more. To edit the latest version of the document, you have to go to https://github.com/npm/npm/edit/latest/doc/cli/npm-bugs.md

This pull request should fix the broken links for all pages.