### PR TITLE
auth-only, create or revoke tokens

### DIFF
--- a/content/getting-started/using-two-factor-authentication.md
+++ b/content/getting-started/using-two-factor-authentication.md
@@ -29,14 +29,15 @@ There are two levels of authentication, ***auth-only*** and ***auth-and-writes**
 If you enable 2FA in **auth-only** mode, npm will require an OTP when you:
 
 * log in
+* create or revoke tokens
 * remove 2FA
 
 If you enable 2FA in **auth-and-writes** mode, which is the default, npm will require an OTP when you:
 
 * log in
 * change your profile
-* create or revoke tokens 
-* publish packages 
+* create or revoke tokens
+* publish packages
 * change access
 * change your password
 * make other sensitive changes to packages


### PR DESCRIPTION
I actually haven't tested this, but the table at the bottom of the page suggests that, in **auth-only** mode, OTP is required for creating and revoking tokens.